### PR TITLE
Add patches for Cyberfox Linux, build Kyberfox and improve install scripts

### DIFF
--- a/_Build/_Linux/KDE/fix_browser_kde.xul.patch
+++ b/_Build/_Linux/KDE/fix_browser_kde.xul.patch
@@ -1,0 +1,70 @@
+diff --git a/browser/base/content/browser-kde.xul b/browser/base/content/browser-kde.xul
+index 7c0a4b7243..66d7e5469a 100644
+--- a/browser/base/content/browser-kde.xul
++++ b/browser/base/content/browser-kde.xul
+@@ -111,9 +111,28 @@
+                    onpopupshowing="gFxAccounts.populateSendTabToDevicesMenu(event.target, TabContextMenu.contextTab.linkedBrowser.currentURI.spec, TabContextMenu.contextTab.linkedBrowser.contentTitle);"/>
+       </menu>
+       <menuseparator/>
++      <menuitem id="context_CopyCurrentTabUrl" 
++					        label="&copyTabURL.label;" 
++					        oncommand="gCyberfoxCustom.CopyCurrentTabUrl(TabContextMenu.contextTab.linkedBrowser.currentURI.spec);"/>
++	    <menuitem id="context_CopyAllTabUrls" 
++					        label="&copyAllTabUrls.label;" 
++					        oncommand="gCyberfoxCustom.CopyAllTabUrls();"/>                  		  
++		  <menuitem id="context_CloneCurrentTab" 
++					        label="&cloneCurrentTab.label;" 
++					        oncommand="gCyberfoxCustom.CloneCurrent('tab');"/>					
++	    <menuitem id="context_CloneCurrentTabNewWindow" 
++					        label="&cloneInNewWindow.label;" 
++					        oncommand="gCyberfoxCustom.CloneCurrent('window');"/>
++	    <menuitem id="context_CloneCurrentTabNewWindowpb" 
++					        label="&cloneInNewWindow.label; (&cloneInNewPrivate.label;)" 
++					        oncommand="gCyberfoxCustom.CloneCurrent('window', true);"/>							
+       <menuitem id="context_reloadAllTabs" label="&reloadAllTabs.label;" accesskey="&reloadAllTabs.accesskey;"
+                 tbattr="tabbrowser-multiple-visible"
+                 oncommand="gBrowser.reloadAllTabs();"/>
++      <menuitem id="context_bookmarkThisPage"
++                observes="bookmarkThisPageBroadcaster"
++                label="&bookmarkThisPageCmd.label;"
++                command="Browser:AddBookmarkAs"/>      
+       <menuitem id="context_bookmarkAllTabs"
+                 label="&bookmarkAllTabs.label;"
+                 accesskey="&bookmarkAllTabs.accesskey;"
+@@ -332,6 +351,9 @@
+                 class="viewCustomizeToolbar"
+                 label="&viewCustomizeToolbar.label;"
+                 accesskey="&viewCustomizeToolbar.accesskey;"/>
++			<menuitem id="menu-aboutconfig"
++				        label="About:Config"
++				        oncommand="gCyberfoxCustom.openAboutConfig();"/>
+     </menupopup>
+ 
+     <menupopup id="blockedPopupOptions"
+@@ -625,6 +647,15 @@
+         </menupopup>
+       </toolbarbutton>
+ 
++<!-- /* Tab Close Button Don't remove */ -->
++      <toolbarbutton id="tabs-closebutton"
++                     class="close-button tabs-closebutton close-icon"
++                     command="cmd_close"
++                     label="&closeTab.label;"
++                     cui-areatype="toolbar"
++                     tooltiptext="&closeTab.label;"/>
++<!-- /* End Tab Close Button Don't remove */ -->
++
+ #if !defined(MOZ_WIDGET_GTK)
+       <hbox class="private-browsing-indicator" skipintoolbarset="true"/>
+ #endif
+@@ -1053,7 +1084,9 @@
+         <sidebarheader id="sidebar-header" align="center">
+           <label id="sidebar-title" persist="value" flex="1" crop="end" control="sidebar"/>
+           <image id="sidebar-throbber"/>
+-          <toolbarbutton class="close-icon tabbable" tooltiptext="&sidebarCloseButton.tooltip;" oncommand="SidebarUI.hide();"/>
++          <!-- /* Tab Close Button Don't remove */ -->
++          <toolbarbutton class="close-icon tabbable tabs-closebutton" tooltiptext="&sidebarCloseButton.tooltip;" oncommand="SidebarUI.hide();"/>
++          <!-- /* End Tab Close Button Don't remove */ -->
+         </sidebarheader>
+         <browser id="sidebar" flex="1" autoscroll="false" disablehistory="true" disablefullscreen="true"
+                   style="min-width: 14em; width: 18em; max-width: 36em;" tooltip="aHTMLTooltip"/>

--- a/_Build/_Linux/KDE/fix_kde_jar.mn.patch
+++ b/_Build/_Linux/KDE/fix_kde_jar.mn.patch
@@ -1,0 +1,258 @@
+diff --git a/browser/base/jar.mn b/browser/base/jar.mn
+index ead893aee0..9be6aa4a68 100644
+--- a/browser/base/jar.mn
++++ b/browser/base/jar.mn
+@@ -64,6 +64,8 @@ browser.jar:
+ *       content/browser/browser.css                   (content/browser.css)
+         content/browser/browser.js                    (content/browser.js)
+ *       content/browser/browser.xul                   (content/browser.xul)
++*       content/browser/browser-kde.xul               (content/browser-kde.xul)
++%       override chrome://browser/content/browser.xul chrome://browser/content/browser-kde.xul desktop=kde
+         content/browser/browser-addons.js             (content/browser-addons.js)
+         content/browser/browser-captivePortal.js      (content/browser-captivePortal.js)
+         content/browser/browser-ctrlTab.js            (content/browser-ctrlTab.js)
+@@ -201,4 +203,4 @@ browser.jar:
+ #Preferences
+ 	content/browser/fonts/ClearSans-Regular.woff  (content/fonts/ClearSans-Regular.woff)
+ 	content/browser/fonts/FiraSans-Regular.woff   (content/fonts/FiraSans-Regular.woff)
+-	content/browser/fonts/FiraSans-Light.woff     (content/fonts/FiraSans-Light.woff)
+\ No newline at end of file
++	content/browser/fonts/FiraSans-Light.woff     (content/fonts/FiraSans-Light.woff)
+diff --git a/browser/base/jar.mn.orig b/browser/base/jar.mn.orig
+deleted file mode 100644
+index ead893aee0..0000000000
+--- a/browser/base/jar.mn.orig
++++ /dev/null
+@@ -1,204 +0,0 @@
+-# This Source Code Form is subject to the terms of the Mozilla Public
+-# License, v. 2.0. If a copy of the MPL was not distributed with this
+-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+-browser.jar:
+-%  content browser %content/browser/ contentaccessible=yes
+-#ifdef XP_MACOSX
+-%  overlay chrome://mozapps/content/downloads/downloads.xul chrome://browser/content/downloadManagerOverlay.xul
+-%  overlay chrome://mozapps/content/update/updates.xul chrome://browser/content/softwareUpdateOverlay.xul
+-#endif
+-#ifdef XP_WIN
+-%  overlay chrome://browser/content/browser.xul chrome://browser/content/win6BrowserOverlay.xul os=WINNT osversion>=6
+-#endif
+-%  overlay chrome://global/content/viewSource.xul chrome://browser/content/viewSourceOverlay.xul
+-%  overlay chrome://global/content/viewPartialSource.xul chrome://browser/content/viewSourceOverlay.xul
+-
+-*       content/browser/aboutDialog.xul               (content/aboutDialog.xul)
+-        content/browser/aboutDialog.js                (content/aboutDialog.js)
+-        content/browser/aboutDialog.css               (content/aboutDialog.css)
+-        content/browser/aboutRobots.xhtml             (content/aboutRobots.xhtml)
+-*       content/browser/abouthome/aboutHome.xhtml     (content/abouthome/aboutHome.xhtml)
+-        content/browser/abouthome/aboutHome.js        (content/abouthome/aboutHome.js)
+-*       content/browser/abouthome/aboutHome.css       (content/abouthome/aboutHome.css)
+-        content/browser/abouthome/downloads.png       (content/abouthome/downloads.png)
+-        content/browser/abouthome/bookmarks.png       (content/abouthome/bookmarks.png)
+-        content/browser/abouthome/history.png         (content/abouthome/history.png)
+-        content/browser/abouthome/addons.png          (content/abouthome/addons.png)
+-        content/browser/abouthome/sync.png            (content/abouthome/sync.png)
+-        content/browser/abouthome/settings.png        (content/abouthome/settings.png)
+-        content/browser/abouthome/restore.png         (content/abouthome/restore.png)
+-        content/browser/abouthome/restore-large.png   (content/abouthome/restore-large.png)
+-        content/browser/abouthome/downloads@2x.png     (content/abouthome/downloads@2x.png)
+-        content/browser/abouthome/bookmarks@2x.png     (content/abouthome/bookmarks@2x.png)
+-        content/browser/abouthome/history@2x.png       (content/abouthome/history@2x.png)
+-        content/browser/abouthome/addons@2x.png        (content/abouthome/addons@2x.png)
+-        content/browser/abouthome/sync@2x.png          (content/abouthome/sync@2x.png)
+-        content/browser/abouthome/settings@2x.png      (content/abouthome/settings@2x.png)
+-        content/browser/abouthome/restore@2x.png       (content/abouthome/restore@2x.png)
+-        content/browser/abouthome/restore-large@2x.png (content/abouthome/restore-large@2x.png)
+-
+-        content/browser/aboutNetError.xhtml            (content/aboutNetError.xhtml)
+-
+-#ifdef MOZ_SERVICES_HEALTHREPORT
+-        content/browser/abouthealthreport/abouthealth.xhtml   (content/abouthealthreport/abouthealth.xhtml)
+-        content/browser/abouthealthreport/abouthealth.js      (content/abouthealthreport/abouthealth.js)
+-        content/browser/abouthealthreport/abouthealth.css     (content/abouthealthreport/abouthealth.css)
+-#endif
+-        content/browser/aboutaccounts/aboutaccounts.xhtml                     (content/aboutaccounts/aboutaccounts.xhtml)
+-        content/browser/aboutaccounts/aboutaccounts.js                        (content/aboutaccounts/aboutaccounts.js)
+-        content/browser/aboutaccounts/aboutaccounts.css                       (content/aboutaccounts/aboutaccounts.css)
+-        content/browser/aboutaccounts/main.css                                (content/aboutaccounts/main.css)
+-        content/browser/aboutaccounts/normalize.css                           (content/aboutaccounts/normalize.css)
+-        content/browser/aboutaccounts/images/fox.png                          (content/aboutaccounts/images/fox.png)
+-        content/browser/aboutaccounts/images/graphic_sync_intro.png           (content/aboutaccounts/images/graphic_sync_intro.png)
+-        content/browser/aboutaccounts/images/graphic_sync_intro@2x.png        (content/aboutaccounts/images/graphic_sync_intro@2x.png)
+-
+-
+-        content/browser/aboutRobots-icon.png          (content/aboutRobots-icon.png)
+-        content/browser/aboutRobots-widget-left.png   (content/aboutRobots-widget-left.png)
+-        content/browser/aboutSocialError.xhtml        (content/aboutSocialError.xhtml)
+-        content/browser/aboutProviderDirectory.xhtml  (content/aboutProviderDirectory.xhtml)
+-        content/browser/aboutTabCrashed.css           (content/aboutTabCrashed.css)
+-        content/browser/aboutTabCrashed.js            (content/aboutTabCrashed.js)
+-        content/browser/aboutTabCrashed.xhtml         (content/aboutTabCrashed.xhtml)
+-*       content/browser/browser.css                   (content/browser.css)
+-        content/browser/browser.js                    (content/browser.js)
+-*       content/browser/browser.xul                   (content/browser.xul)
+-        content/browser/browser-addons.js             (content/browser-addons.js)
+-        content/browser/browser-captivePortal.js      (content/browser-captivePortal.js)
+-        content/browser/browser-ctrlTab.js            (content/browser-ctrlTab.js)
+-        content/browser/browser-customization.js      (content/browser-customization.js)
+-        content/browser/browser-devedition.js         (content/browser-devedition.js)
+-        content/browser/browser-feeds.js              (content/browser-feeds.js)
+-        content/browser/browser-fullScreenAndPointerLock.js  (content/browser-fullScreenAndPointerLock.js)
+-        content/browser/browser-fullZoom.js           (content/browser-fullZoom.js)
+-        content/browser/browser-fxaccounts.js         (content/browser-fxaccounts.js)
+-        content/browser/browser-gestureSupport.js     (content/browser-gestureSupport.js)
+-        content/browser/browser-media.js              (content/browser-media.js)
+-        content/browser/browser-places.js             (content/browser-places.js)
+-        content/browser/browser-plugins.js            (content/browser-plugins.js)
+-        content/browser/browser-refreshblocker.js     (content/browser-refreshblocker.js)
+-        content/browser/browser-safebrowsing.js       (content/browser-safebrowsing.js)
+-        content/browser/browser-sidebar.js            (content/browser-sidebar.js)
+-        content/browser/browser-social.js             (content/browser-social.js)
+-        content/browser/browser-syncui.js             (content/browser-syncui.js)
+-*       content/browser/browser-tabPreviews.xml       (content/browser-tabPreviews.xml)
+-#ifdef CAN_DRAW_IN_TITLEBAR
+-        content/browser/browser-tabsintitlebar.js       (content/browser-tabsintitlebar.js)
+-#else
+-        content/browser/browser-tabsintitlebar.js       (content/browser-tabsintitlebar-stub.js)
+-#endif
+-        content/browser/browser-thumbnails.js         (content/browser-thumbnails.js)
+-        content/browser/browser-trackingprotection.js (content/browser-trackingprotection.js)
+-        content/browser/tab-content.js                (content/tab-content.js)
+-        content/browser/content.js                    (content/content.js)
+-        content/browser/social-content.js             (content/social-content.js)
+-        content/browser/defaultthemes/1.footer.jpg    (content/defaultthemes/1.footer.jpg)
+-        content/browser/defaultthemes/1.header.jpg    (content/defaultthemes/1.header.jpg)
+-        content/browser/defaultthemes/1.icon.jpg      (content/defaultthemes/1.icon.jpg)
+-        content/browser/defaultthemes/1.preview.jpg   (content/defaultthemes/1.preview.jpg)
+-        content/browser/defaultthemes/2.footer.jpg    (content/defaultthemes/2.footer.jpg)
+-        content/browser/defaultthemes/2.header.jpg    (content/defaultthemes/2.header.jpg)
+-        content/browser/defaultthemes/2.icon.jpg      (content/defaultthemes/2.icon.jpg)
+-        content/browser/defaultthemes/2.preview.jpg   (content/defaultthemes/2.preview.jpg)
+-        content/browser/defaultthemes/3.footer.png    (content/defaultthemes/3.footer.png)
+-        content/browser/defaultthemes/3.header.png    (content/defaultthemes/3.header.png)
+-        content/browser/defaultthemes/3.icon.png      (content/defaultthemes/3.icon.png)
+-        content/browser/defaultthemes/3.preview.png   (content/defaultthemes/3.preview.png)
+-        content/browser/defaultthemes/4.footer.png    (content/defaultthemes/4.footer.png)
+-        content/browser/defaultthemes/4.header.png    (content/defaultthemes/4.header.png)
+-        content/browser/defaultthemes/4.icon.png      (content/defaultthemes/4.icon.png)
+-        content/browser/defaultthemes/4.preview.png   (content/defaultthemes/4.preview.png)
+-        content/browser/defaultthemes/5.footer.png    (content/defaultthemes/5.footer.png)
+-        content/browser/defaultthemes/5.header.png    (content/defaultthemes/5.header.png)
+-        content/browser/defaultthemes/5.icon.jpg      (content/defaultthemes/5.icon.jpg)
+-        content/browser/defaultthemes/5.preview.jpg   (content/defaultthemes/5.preview.jpg)
+-        content/browser/defaultthemes/devedition.header.png   (content/defaultthemes/devedition.header.png)
+-        content/browser/defaultthemes/devedition.icon.png     (content/defaultthemes/devedition.icon.png)
+-        content/browser/gcli_sec_bad.svg              (content/gcli_sec_bad.svg)
+-        content/browser/gcli_sec_good.svg             (content/gcli_sec_good.svg)
+-        content/browser/gcli_sec_moderate.svg         (content/gcli_sec_moderate.svg)
+-        content/browser/newtab/newTab.xhtml           (content/newtab/newTab.xhtml)
+-*       content/browser/newtab/newTab.js              (content/newtab/newTab.js)
+-        content/browser/newtab/newTab.css             (content/newtab/newTab.css)
+-        content/browser/newtab/newTab.inadjacent.json         (content/newtab/newTab.inadjacent.json)
+-        content/browser/newtab/alternativeDefaultSites.json   (content/newtab/alternativeDefaultSites.json)
+-*       content/browser/pageinfo/pageInfo.xul         (content/pageinfo/pageInfo.xul)
+-        content/browser/pageinfo/pageInfo.js          (content/pageinfo/pageInfo.js)
+-        content/browser/pageinfo/pageInfo.css         (content/pageinfo/pageInfo.css)
+-        content/browser/pageinfo/pageInfo.xml         (content/pageinfo/pageInfo.xml)
+-        content/browser/pageinfo/feeds.js             (content/pageinfo/feeds.js)
+-        content/browser/pageinfo/feeds.xml            (content/pageinfo/feeds.xml)
+-        content/browser/pageinfo/permissions.js       (content/pageinfo/permissions.js)
+-        content/browser/pageinfo/security.js          (content/pageinfo/security.js)
+-        content/browser/sync/aboutSyncTabs.xul        (content/sync/aboutSyncTabs.xul)
+-        content/browser/sync/aboutSyncTabs.js         (content/sync/aboutSyncTabs.js)
+-        content/browser/sync/aboutSyncTabs.css        (content/sync/aboutSyncTabs.css)
+-        content/browser/sync/aboutSyncTabs-bindings.xml  (content/sync/aboutSyncTabs-bindings.xml)
+-        content/browser/sync/setup.xul                (content/sync/setup.xul)
+-        content/browser/sync/addDevice.js             (content/sync/addDevice.js)
+-        content/browser/sync/addDevice.xul            (content/sync/addDevice.xul)
+-        content/browser/sync/setup.js                 (content/sync/setup.js)
+-        content/browser/sync/genericChange.xul        (content/sync/genericChange.xul)
+-        content/browser/sync/genericChange.js         (content/sync/genericChange.js)
+-        content/browser/sync/key.xhtml                (content/sync/key.xhtml)
+-        content/browser/sync/utils.js                 (content/sync/utils.js)
+-*       content/browser/sync/customize.xul            (content/sync/customize.xul)
+-        content/browser/sync/customize.js             (content/sync/customize.js)
+-        content/browser/sync/customize.css            (content/sync/customize.css)
+-        content/browser/safeMode.css                  (content/safeMode.css)
+-        content/browser/safeMode.js                   (content/safeMode.js)
+-        content/browser/safeMode.xul                  (content/safeMode.xul)
+-        content/browser/sanitize.js                   (content/sanitize.js)
+-*       content/browser/sanitize.xul                  (content/sanitize.xul)
+-*       content/browser/sanitizeDialog.js             (content/sanitizeDialog.js)
+-        content/browser/sanitizeDialog.css            (content/sanitizeDialog.css)
+-        content/browser/contentSearchUI.js            (content/contentSearchUI.js)
+-        content/browser/contentSearchUI.css           (content/contentSearchUI.css)
+-        content/browser/tabbrowser.css                (content/tabbrowser.css)
+-        content/browser/tabbrowser.xml                (content/tabbrowser.xml)
+-        content/browser/urlbarBindings.xml            (content/urlbarBindings.xml)
+-        content/browser/utilityOverlay.js             (content/utilityOverlay.js)
+-        content/browser/usercontext.svg               (content/usercontext.svg)
+-        content/browser/web-panels.js                 (content/web-panels.js)
+-*       content/browser/web-panels.xul                (content/web-panels.xul)
+-*       content/browser/baseMenuOverlay.xul           (content/baseMenuOverlay.xul)
+-*       content/browser/nsContextMenu.js              (content/nsContextMenu.js)
+-# XXX: We should exclude this one as well (bug 71895)
+-*       content/browser/hiddenWindow.xul              (content/hiddenWindow.xul)
+-#ifdef XP_MACOSX
+-*       content/browser/macBrowserOverlay.xul         (content/macBrowserOverlay.xul)
+-*       content/browser/downloadManagerOverlay.xul    (content/downloadManagerOverlay.xul)
+-*       content/browser/softwareUpdateOverlay.xul  (content/softwareUpdateOverlay.xul)
+-#endif
+-*       content/browser/viewSourceOverlay.xul         (content/viewSourceOverlay.xul)
+-#ifndef XP_MACOSX
+-*       content/browser/webrtcIndicator.xul           (content/webrtcIndicator.xul)
+-        content/browser/webrtcIndicator.js            (content/webrtcIndicator.js)
+-#endif
+-#ifdef XP_WIN
+-        content/browser/win6BrowserOverlay.xul        (content/win6BrowserOverlay.xul)
+-#endif
+-# the following files are browser-specific overrides
+-*       content/browser/license.html                  (/toolkit/content/license.html)
+-% override chrome://global/content/license.html chrome://browser/content/license.html
+-        content/browser/report-phishing-overlay.xul     (content/report-phishing-overlay.xul)
+-        content/browser/blockedSite.xhtml               (content/blockedSite.xhtml)
+-% overlay chrome://browser/content/browser.xul chrome://browser/content/report-phishing-overlay.xul
+-
+-% override chrome://global/content/netError.xhtml chrome://browser/content/aboutNetError.xhtml
+-
+-# Add Files For Cyberfox
+-
+-#About:Home
+-	content/browser/abouthome/cyber-light.png     	    (content/abouthome/cyber-light.png)
+-	content/browser/abouthome/cyber-dark.png     	    (content/abouthome/cyber-dark.png)
+-  content/browser/abouthome/noise.png           (content/abouthome/noise.png)		
+-#Browser Core
+-	content/browser/browser-cyberfox.js           (content/browser-cyberfox.js)
+-	content/browser/browser-cyberfox.xul          (content/browser-cyberfox.xul)
+-	content/browser/browser-cyberfox.css          (content/browser-cyberfox.css)
+-#Preferences
+-	content/browser/fonts/ClearSans-Regular.woff  (content/fonts/ClearSans-Regular.woff)
+-	content/browser/fonts/FiraSans-Regular.woff   (content/fonts/FiraSans-Regular.woff)
+-	content/browser/fonts/FiraSans-Light.woff     (content/fonts/FiraSans-Light.woff)
+\ No newline at end of file
+diff --git a/browser/base/jar.mn.rej b/browser/base/jar.mn.rej
+deleted file mode 100644
+index f9f6acc095..0000000000
+--- a/browser/base/jar.mn.rej
++++ /dev/null
+@@ -1,21 +0,0 @@
+---- browser/base/jar.mn
+-+++ browser/base/jar.mn
+-@@ -66,16 +66,18 @@ browser.jar:
+-         content/browser/aboutSocialError.xhtml        (content/aboutSocialError.xhtml)
+-         content/browser/aboutProviderDirectory.xhtml  (content/aboutProviderDirectory.xhtml)
+-         content/browser/aboutTabCrashed.css           (content/aboutTabCrashed.css)
+-         content/browser/aboutTabCrashed.js            (content/aboutTabCrashed.js)
+-         content/browser/aboutTabCrashed.xhtml         (content/aboutTabCrashed.xhtml)
+- *       content/browser/browser.css                   (content/browser.css)
+-         content/browser/browser.js                    (content/browser.js)
+- *       content/browser/browser.xul                   (content/browser.xul)
+-+*       content/browser/browser-kde.xul               (content/browser-kde.xul)
+-+%       override chrome://browser/content/browser.xul chrome://browser/content/browser-kde.xul desktop=kde
+-         content/browser/browser-addons.js             (content/browser-addons.js)
+-         content/browser/browser-captivePortal.js      (content/browser-captivePortal.js)
+-         content/browser/browser-ctrlTab.js            (content/browser-ctrlTab.js)
+-         content/browser/browser-customization.js      (content/browser-customization.js)
+-         content/browser/browser-data-submission-info-bar.js (content/browser-data-submission-info-bar.js)
+-         content/browser/browser-devedition.js         (content/browser-devedition.js)
+-         content/browser/browser-feeds.js              (content/browser-feeds.js)
+-         content/browser/browser-fullScreenAndPointerLock.js  (content/browser-fullScreenAndPointerLock.js)

--- a/_Build/_Linux/KDE/kde.js
+++ b/_Build/_Linux/KDE/kde.js
@@ -1,0 +1,1 @@
+pref("browser.preferences.instantApply", false);

--- a/_Build/_Linux/KDE/pgo_fix_missing_kdejs.patch
+++ b/_Build/_Linux/KDE/pgo_fix_missing_kdejs.patch
@@ -1,0 +1,10 @@
+--- b/browser/app/Makefile.in	2016-02-14 15:57:50.000000000 +0100
++++ a/browser/app/Makefile.in	2016-02-14 16:08:29.823744590 +0100
+@@ -71,6 +71,7 @@
+ libs:: $(srcdir)/profile/channel-prefs.js
+ 	$(NSINSTALL) -D $(DIST)/bin/defaults/pref
+ 	$(call py_action,preprocessor,-Fsubstitution $(PREF_PPFLAGS) $(ACDEFINES) $^ -o $(DIST)/bin/defaults/pref/channel-prefs.js)
++	cp $(topsrcdir)/_Build/_Linux/KDE/kde.js $(DIST)/bin/defaults/pref/kde.js	
+ 
+ ifeq (cocoa,$(MOZ_WIDGET_TOOLKIT))
+ 

--- a/_Build/_Linux/all/fix-wifi-scanner.diff
+++ b/_Build/_Linux/all/fix-wifi-scanner.diff
@@ -1,0 +1,16 @@
+ netwerk/wifi/nsWifiScannerDBus.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git c/netwerk/wifi/nsWifiScannerDBus.cpp i/netwerk/wifi/nsWifiScannerDBus.cpp
+index 182553e18fa6e104..6fa0a0b023d3e45f 100644
+--- c/netwerk/wifi/nsWifiScannerDBus.cpp
++++ i/netwerk/wifi/nsWifiScannerDBus.cpp
+@@ -62,7 +62,7 @@ nsWifiScannerDBus::SendMessage(const char* aInterface,
+       return NS_ERROR_FAILURE;
+     }
+   } else if (!strcmp(aFuncCall, "GetAll")) {
+-    const char* param = "";
++    const char* param = "org.freedesktop.NetworkManager.AccessPoint";
+     if (!dbus_message_iter_append_basic(&argsIter, DBUS_TYPE_STRING, &param)) {
+       return NS_ERROR_FAILURE;
+     }

--- a/_Build/_Linux/install_cyberfox.sh
+++ b/_Build/_Linux/install_cyberfox.sh
@@ -1,6 +1,6 @@
-# Cyberfox Installation, Shortcut Desktop, (Optional) Shortcut Menu, Cyberfox Uninstall
-# Version: 1.4
-# Release, Beta channels linux
+# Cyberfox Installation, Shortcut Menu, (Optional) Shortcut Desktop, Cyberfox Uninstall
+# Version: 1.5
+# Release, Beta channels Linux
 
 #!/bin/bash
 
@@ -17,7 +17,11 @@ PackageCount=`ls Cyberfox*.tar.bz2 | awk 'END { print NR }'`
 Package=$Dir/Cyberfox-*.tar.bz2
 
 # Desktop shortcut path, Applications shortcut path, Cyberfox install path.
-Desktop=~/Desktop/cyberfox.desktop
+# We need to know path to Desktop for not English operating systems
+: ${XDG_CONFIG_HOME:=~/.config}
+[ -f "${XDG_CONFIG_HOME}/user-dirs.dirs" ] && . "${XDG_CONFIG_HOME}/user-dirs.dirs"
+
+Desktop="${XDG_DESKTOP_DIR:-~/Desktop}"
 Applications=/usr/share/applications
 InstallDirectory=$HOME/Apps
 
@@ -60,41 +64,238 @@ select yn in "Install" "Uninstall" "Quit"; do
             if [ -f $InstallDirectory/README.txt ]; then
                 rm -rvf $InstallDirectory/README.txt;
             fi
-
-            # Create desktop shortcut
-            echo "Generating desktop shortcut"
-            echo "[Desktop Entry]" > $Desktop
-            echo "Encoding=UTF-8" >> $Desktop
-            echo "Name=Cyberfox" >> $Desktop
-            echo "Comment=Starts Cyberfox Web Browser" >> $Desktop
-            echo "Exec=$InstallDirectory/Cyberfox/Cyberfox" >> $Desktop
-            echo "Icon=$InstallDirectory/Cyberfox/browser/icons/mozicon128.png" >> $Desktop
-            echo "Terminal=false" >> $Desktop
-            echo "X-MuiltpleArgs=false" >> $Desktop
-            echo "StartupWMClass=Cyberfox" >> $Desktop
-            echo "Type=Application" >> $Desktop
-            echo "Categories=Network;WebBrowser;" >> $Desktop
-            echo "MimeType=text/html;text/xml;application/xhtml+xml;application/xml;application/rss+xml;application/rdf+xml;image/gif;image/jpeg;image/png;x-scheme-handler/http;x-scheme-handler/https;x-scheme-handler/ftp;x-scheme-handler/chrome;video/webm;application/x-xpinstall;" >> $Desktop
-            chmod +x $Desktop
-
-            # Clone shortcut to /usr/share/applications for access in menus i.e mint, ubuntu search etc
-            echo "Do you wish to add a shortcut to your startmenu (Requires SUDO)?"
+            
+            # Create symlinks
+            echo "Creating symlinks (Root priveleges are required)..."
+            sudo ln -sf $InstallDirectory/Cyberfox/Cyberfox /usr/bin/cyberfox
+            sudo ln -sf $InstallDirectory/Cyberfox/browser/icons/mozicon128.png /usr/share/pixmaps/cyberfox.png
+            
+            echo "Do you wish to add symlink to system's hunspell dictionaries for Cyberfox (Root priveleges are required)?"
             select yn in "Yes" "No"; do
                 case $yn in
                     Yes )
-                        echo "To add a copy of the desktop shortcut to $Applications SUDO is required!"
-                        echo "Generating menu shortcut"
-                        # Requires admin permissions to write the file to /usr/share/applications directory.
-                        sudo cp $Desktop $Applications
+                        echo "Adding symlink to hunspell..."
+                        rm -rf $InstallDirectory/Cyberfox/dictionaries
+                        sudo ln -sf /usr/share/hunspell $InstallDirectory/Cyberfox/dictionaries
+                    break;;
+                    No ) break;;
+                    esac
+                done
+            
+            
+            # Create start menu shortcut
+            echo "Generating start menu shortcut..."
+            mkdir $InstallDirectory/Cyberfox/tmp
+            cat > $InstallDirectory/Cyberfox/tmp/cyberfox.desktop <<EOF
+[Desktop Entry]
+Version=1.0
+Encoding=UTF-8
+Name=Cyberfox
+Comment=Browse the World Wide Web with Cyberfox Web Browser
+Comment[ar]=تصفح الشبكة العنكبوتية العالمية
+Comment[ast]=Restola pela Rede
+Comment[bn]=ইন্টারনেট ব্রাউজ করুন
+Comment[ca]=Navegueu per la web
+Comment[cs]=Prohlížení stránek World Wide Webu
+Comment[da]=Surf på internettet
+Comment[de]=Im Internet surfen
+Comment[el]=Μπορείτε να περιηγηθείτε στο διαδίκτυο (Web)
+Comment[es]=Navegue por la web
+Comment[et]=Lehitse veebi
+Comment[fa]=صفحات شبکه جهانی اینترنت را مرور نمایید
+Comment[fi]=Selaa Internetin WWW-sivuja
+Comment[fr]=Naviguer sur le Web
+Comment[gl]=Navegar pola rede
+Comment[he]=גלישה ברחבי האינטרנט
+Comment[hr]=Pretražite web
+Comment[hu]=A világháló böngészése
+Comment[it]=Esplora il web
+Comment[ja]=ウェブを閲覧します
+Comment[ko]=웹을 돌아 다닙니다
+Comment[ku]=Li torê bigere
+Comment[lt]=Naršykite internete
+Comment[nb]=Surf på nettet
+Comment[nl]=Verken het internet
+Comment[nn]=Surf på nettet
+Comment[no]=Surf på nettet
+Comment[pl]=Przeglądaj strony WWW z przeglądarką internetową Cyberfox
+Comment[pt]=Explorar a Internet com o Cyberfox
+Comment[pt_BR]=Navegue na Internet
+Comment[ro]=Navigați pe Internet
+Comment[ru]=Доступ в Интернет
+Comment[sk]=Prehliadanie internetu
+Comment[sl]=Brskajte po spletu
+Comment[sv]=Surfa på webben
+Comment[tr]=İnternet'te Gezinin
+Comment[ug]=دۇنيادىكى توربەتلەرنى كۆرگىلى بولىدۇ
+Comment[uk]=Перегляд сторінок Інтернету
+Comment[vi]=Để duyệt các trang web
+Comment[zh_CN]=浏览互联网
+Comment[zh_TW]=瀏覽網際網路
+GenericName=Web Browser
+GenericName[ar]=متصفح ويب
+GenericName[ast]=Restolador Web
+GenericName[bn]=ওয়েব ব্রাউজার
+GenericName[ca]=Navegador web
+GenericName[cs]=Webový prohlížeč
+GenericName[da]=Webbrowser
+GenericName[el]=Περιηγητής διαδικτύου
+GenericName[es]=Navegador web
+GenericName[et]=Veebibrauser
+GenericName[fa]=مرورگر اینترنتی
+GenericName[fi]=WWW-selain
+GenericName[fr]=Navigateur Web
+GenericName[gl]=Navegador Web
+GenericName[he]=דפדפן אינטרנט
+GenericName[hr]=Web preglednik
+GenericName[hu]=Webböngésző
+GenericName[it]=Browser web
+GenericName[ja]=ウェブ・ブラウザ
+GenericName[ko]=웹 브라우저
+GenericName[ku]=Geroka torê
+GenericName[lt]=Interneto naršyklė
+GenericName[nb]=Nettleser
+GenericName[nl]=Webbrowser
+GenericName[nn]=Nettlesar
+GenericName[no]=Nettleser
+GenericName[pl]=Przeglądarka WWW
+GenericName[pt]=Navegador web
+GenericName[pt_BR]=Navegador Web
+GenericName[ro]=Navigator Internet
+GenericName[ru]=Веб-браузер
+GenericName[sk]=Internetový prehliadač
+GenericName[sl]=Spletni brskalnik
+GenericName[sv]=Webbläsare
+GenericName[tr]=Web Tarayıcı
+GenericName[ug]=توركۆرگۈ
+GenericName[uk]=Веб-браузер
+GenericName[vi]=Trình duyệt Web
+GenericName[zh_CN]=网络浏览器
+GenericName[zh_TW]=網路瀏覽器
+Keywords=Internet;WWW;Browser;Web;Explorer
+Keywords[ar]=انترنت;إنترنت;متصفح;ويب;وب
+Keywords[ast]=Internet;WWW;Restolador;Web;Esplorador
+Keywords[ca]=Internet;WWW;Navegador;Web;Explorador;Explorer
+Keywords[cs]=Internet;WWW;Prohlížeč;Web;Explorer
+Keywords[da]=Internet;Internettet;WWW;Browser;Browse;Web;Surf;Nettet
+Keywords[de]=Internet;WWW;Browser;Web;Explorer;Webseite;Site;surfen;online;browsen
+Keywords[el]=Internet;WWW;Browser;Web;Explorer;Διαδίκτυο;Περιηγητής;Cyberfox;Φιρεφοχ;Ιντερνετ
+Keywords[es]=Explorador;Internet;WWW
+Keywords[fi]=Internet;WWW;Browser;Web;Explorer;selain;Internet-selain;internetselain;verkkoselain;netti;surffaa
+Keywords[fr]=Internet;WWW;Browser;Web;Explorer;Fureteur;Surfer;Navigateur
+Keywords[he]=דפדפן;אינטרנט;רשת;אתרים;אתר;פיירפוקס;מוזילה;
+Keywords[hr]=Internet;WWW;preglednik;Web
+Keywords[hu]=Internet;WWW;Böngésző;Web;Háló;Net;Explorer
+Keywords[it]=Internet;WWW;Browser;Web;Navigatore
+Keywords[is]=Internet;WWW;Vafri;Vefur;Netvafri;Flakk
+Keywords[ja]=Internet;WWW;Web;インターネット;ブラウザ;ウェブ;エクスプローラ
+Keywords[nb]=Internett;WWW;Nettleser;Explorer;Web;Browser;Nettside
+Keywords[nl]=Internet;WWW;Browser;Web;Explorer;Verkenner;Website;Surfen;Online 
+Keywords[pl]=Internet;WWW;Przeglądarka;Sieć;Surfowanie;Strona internetowa;Strona;Przeglądanie
+Keywords[pt]=Internet;WWW;Browser;Web;Explorador;Navegador
+Keywords[pt_BR]=Internet;WWW;Browser;Web;Explorador;Navegador
+Keywords[ru]=Internet;WWW;Browser;Web;Explorer;интернет;браузер;веб;файрфокс;огнелис
+Keywords[sk]=Internet;WWW;Prehliadač;Web;Explorer
+Keywords[sl]=Internet;WWW;Browser;Web;Explorer;Brskalnik;Splet
+Keywords[tr]=İnternet;WWW;Tarayıcı;Web;Gezgin;Web sitesi;Site;sörf;çevrimiçi;tara
+Keywords[uk]=Internet;WWW;Browser;Web;Explorer;Інтернет;мережа;переглядач;оглядач;браузер;веб;файрфокс;вогнелис;перегляд
+Keywords[vi]=Internet;WWW;Browser;Web;Explorer;Trình duyệt;Trang web
+Keywords[zh_CN]=Internet;WWW;Browser;Web;Explorer;网页;浏览;上网;火狐;Cyberfox;互联网;网站;
+Keywords[zh_TW]=Internet;WWW;Browser;Web;Explorer;網際網路;網路;瀏覽器;上網;網頁;火狐
+Exec=cyberfox %u
+Terminal=false
+X-MuiltpleArgs=false
+Type=Application
+Icon=cyberfox
+Categories=Network;WebBrowser;
+MimeType=text/html;text/xml;application/xhtml+xml;application/xml;application/rss+xml;application/rdf+xml;image/gif;image/jpeg;image/png;x-scheme-handler/http;x-scheme-handler/https;x-scheme-handler/ftp;x-scheme-handler/chrome;video/webm;application/x-xpinstall;
+StartupWMClass=Cyberfox
+StartupNotify=true
+Actions=NewWindow;NewPrivateWindow;
+
+[Desktop Action NewWindow]
+Name=Open a New Window
+Name[ar]=افتح نافذة جديدة
+Name[ast]=Abrir una ventana nueva
+Name[bn]=Abrir una ventana nueva
+Name[ca]=Obre una finestra nova
+Name[cs]=Otevřít nové okno
+Name[da]=Åbn et nyt vindue
+Name[de]=Ein neues Fenster öffnen
+Name[el]=Άνοιγμα νέου παραθύρου
+Name[es]=Abrir una ventana nueva
+Name[fi]=Avaa uusi ikkuna
+Name[fr]=Ouvrir une nouvelle fenêtre
+Name[gl]=Abrir unha nova xanela
+Name[he]=פתיחת חלון חדש
+Name[hr]=Otvori novi prozor
+Name[hu]=Új ablak nyitása
+Name[it]=Apri una nuova finestra
+Name[ja]=新しいウィンドウを開く
+Name[ko]=새 창 열기
+Name[ku]=Paceyeke nû veke
+Name[lt]=Atverti naują langą
+Name[nb]=Åpne et nytt vindu
+Name[nl]=Nieuw venster openen
+Name[pl]=Otwórz nowe okno
+Name[pt]=Abrir uma nova janela
+Name[pt_BR]=Abrir nova janela
+Name[ro]=Deschide o fereastră nouă
+Name[ru]=Новое окно
+Name[sk]=Otvoriť nové okno
+Name[sl]=Odpri novo okno
+Name[sv]=Öppna ett nytt fönster
+Name[tr]=Yeni pencere aç 
+Name[ug]=يېڭى كۆزنەك ئېچىش
+Name[uk]=Відкрити нове вікно
+Name[vi]=Mở cửa sổ mới
+Name[zh_CN]=新建窗口
+Name[zh_TW]=開啟新視窗
+Exec=cyberfox -new-window
+
+[Desktop Action NewPrivateWindow]
+Name=Open a New Private Window
+Name[ar]=افتح نافذة جديدة للتصفح الخاص
+Name[ca]=Obre una finestra nova en mode d'incògnit
+Name[de]=Ein neues privates Fenster öffnen
+Name[es]=Abrir una ventana privada nueva
+Name[fi]=Avaa uusi yksityinen ikkuna
+Name[fr]=Ouvrir une nouvelle fenêtre de navigation privée
+Name[he]=פתיחת חלון גלישה פרטית חדש
+Name[hu]=Új privát ablak nyitása
+Name[it]=Apri una nuova finestra anonima
+Name[nb]=Åpne et nytt privat vindu
+Name[pl]=Otwórz nowe okno prywatne
+Name[pt]=Abrir uma nova janela privada
+Name[ru]=Новое приватное окно
+Name[sl]=Odpri novo okno zasebnega brskanja
+Name[tr]=Yeni bir pencere aç
+Name[uk]=Відкрити нове вікно у потайливому режимі
+Name[zh_TW]=開啟新隱私瀏覽視窗
+Exec=cyberfox -private-window
+EOF
+            echo "Installing start menu shortcut..."
+            chmod +x $InstallDirectory/Cyberfox/tmp/cyberfox.desktop
+            sudo cp $InstallDirectory/Cyberfox/tmp/cyberfox.desktop $Applications/
+
+            # Install optional desktop shortcut
+            echo "Do you wish to add a desktop shortcut (Root priveleges are required)?"
+            select yn in "Yes" "No"; do
+                case $yn in
+                    Yes )
+                        echo "Generating desktop shortcut..."
+                        sudo ln -sf $Applications/cyberfox.desktop $Desktop/cyberfox.desktop
                     break;;
                     No ) break;;
                 esac
             done
             echo "Cyberfox is now ready for use!"
-            notify-send "Installation Compelete"
+            notify-send "Installation Complete!"
         else
             echo "You must place this script next to the 'Cyberfox' tar.bz2 package."
-        fi; break;;
+        fi; 
+        rm -rf $InstallDirectory/Cyberfox/tmp
+        break;;
         Uninstall )
 
             # Navigate in to apps directory
@@ -108,17 +309,31 @@ select yn in "Install" "Uninstall" "Quit"; do
             fi
 
             # Remove cyberfox desktop icon if exists.
-            if [ -f $Desktop ]; then
-                rm -vf $Desktop;
+            if [ -f $Desktop/cyberfox.desktop ]; then
+                rm -vrf $Desktop/cyberfox.desktop;
             fi
 			
             # Remove menu icon if exists.
             # Requires admin permissions to write the file to /usr/share/applications directory.
             # This should only prompt if the user installed it, Meaning if the check for the file returns true.
             if [ -f $Applications/cyberfox.desktop ]; then
-                sudo rm -vf $Applications/cyberfox.desktop;
+                sudo rm -vrf $Applications/cyberfox.desktop;
             fi
-
+            
+            # Remove symlinks
+            if [ -L /usr/bin/cyberfox ]; then
+                sudo rm -vrf /usr/bin/cyberfox;
+            fi
+            
+            if [ -L /usr/share/pixmaps/cyberfox.png ]; then
+                sudo rm -vrf /usr/share/pixmaps/cyberfox.png;
+            fi
+            
+            # Remove ~/Apps if is empty
+            if [ ! "$(ls -A $InstallDirectory)" ]; then
+                rmdir $InstallDirectory;
+            fi
+            
 			notify-send "Uninstall Complete"
         break;;
 	  "Quit" )

--- a/_Build/_Linux/install_kyberfox.sh
+++ b/_Build/_Linux/install_kyberfox.sh
@@ -1,6 +1,6 @@
-# Cyberfox KDE Plasma Edition Installation, Shortcut Desktop, (Optional) Shortcut Menu, Cyberfox KDE Plasma Edition Uninstall
+# Cyberfox KDE Plasma Edition Installation, Shortcut Menu, (Optional) Shortcut Desktop,  Cyberfox KDE Plasma Edition Uninstall
 # Version: 1.0
-# Release, Beta channels linux
+# Release, Beta channels Linux
 
 #!/bin/bash
 
@@ -16,13 +16,17 @@ PackageCount=`ls Cyberfox_KDE_Plasma_Edition-*.tar.bz2 | awk 'END { print NR }'`
 # Make package name editable in single place in the event of file naming change.
 Package=$Dir/Cyberfox_KDE_Plasma_Edition-*.tar.bz2
 
-# Desktop shortcut path, Applications shortcut path, Cyberfox install path.
-Desktop=~/Desktop/cyberfox.desktop
+# Desktop shortcut path, Applications shortcut path, Kyberfox install path.
+# We need to know path to Desktop for not English operating systems
+: ${XDG_CONFIG_HOME:=~/.config}
+[ -f "${XDG_CONFIG_HOME}/user-dirs.dirs" ] && . "${XDG_CONFIG_HOME}/user-dirs.dirs"
+
+Desktop="${XDG_DESKTOP_DIR:-~/Desktop}"
 Applications=/usr/share/applications
 InstallDirectory=$HOME/Apps
 
 # Check if the script is in the right place before checking file hashes.
-echo "Do you wish to install Cyberfox now?"
+echo "Do you wish to install Cyberfox KDE Plasma Edition now?"
 select yn in "Install" "Uninstall" "Quit"; do
     case $yn in
         Install )
@@ -62,52 +66,250 @@ select yn in "Install" "Uninstall" "Quit"; do
             fi
 
             # Create desktop shortcut
-            echo "Generating desktop shortcut"
-            echo "[Desktop Entry]" > $Desktop
-            echo "Encoding=UTF-8" >> $Desktop
-            echo "Name=Cyberfox" >> $Desktop
-            echo "Comment=Starts Cyberfox Web Browser" >> $Desktop
-            echo "Exec=$InstallDirectory/Cyberfox/Cyberfox" >> $Desktop
-            echo "Icon=$InstallDirectory/Cyberfox/browser/icons/mozicon128.png" >> $Desktop
-            echo "Terminal=false" >> $Desktop
-            echo "X-MuiltpleArgs=false" >> $Desktop
-            echo "StartupWMClass=Cyberfox" >> $Desktop
-            echo "Type=Application" >> $Desktop
-            echo "Categories=Network;WebBrowser;" >> $Desktop
-            echo "MimeType=text/html;text/xml;application/xhtml+xml;application/xml;application/rss+xml;application/rdf+xml;image/gif;image/jpeg;image/png;x-scheme-handler/http;x-scheme-handler/https;x-scheme-handler/ftp;x-scheme-handler/chrome;video/webm;application/x-xpinstall;" >> $Desktop
-            chmod +x $Desktop
+            # Create symlinks
+            echo "Creating symlinks (Root priveleges are required)..."
+            sudo ln -sf $InstallDirectory/Cyberfox/Cyberfox /usr/bin/cyberfox
+            sudo ln -sf $InstallDirectory/Cyberfox/browser/icons/mozicon128.png /usr/share/pixmaps/cyberfox.png
+            
+            echo "Do you wish to add symlink to system's hunspell dictionaries for Cyberfox (Root priveleges are required)?"
+            select yn in "Yes" "No"; do
+                case $yn in
+                    Yes )
+                        echo "Adding symlink to hunspell..."
+                        rm -rf $InstallDirectory/Cyberfox/dictionaries
+                        sudo ln -sf /usr/share/hunspell $InstallDirectory/Cyberfox/dictionaries
+                    break;;
+                    No ) break;;
+                    esac
+                done
+            
+            
+            # Create start menu shortcut
+            echo "Generating start menu shortcut..."
+            mkdir $InstallDirectory/Cyberfox/tmp
+            cat > $InstallDirectory/Cyberfox/tmp/cyberfox.desktop <<EOF
+[Desktop Entry]
+Version=1.0
+Encoding=UTF-8
+Name=Cyberfox
+Comment=Browse the World Wide Web with Cyberfox Web Browser
+Comment[ar]=تصفح الشبكة العنكبوتية العالمية
+Comment[ast]=Restola pela Rede
+Comment[bn]=ইন্টারনেট ব্রাউজ করুন
+Comment[ca]=Navegueu per la web
+Comment[cs]=Prohlížení stránek World Wide Webu
+Comment[da]=Surf på internettet
+Comment[de]=Im Internet surfen
+Comment[el]=Μπορείτε να περιηγηθείτε στο διαδίκτυο (Web)
+Comment[es]=Navegue por la web
+Comment[et]=Lehitse veebi
+Comment[fa]=صفحات شبکه جهانی اینترنت را مرور نمایید
+Comment[fi]=Selaa Internetin WWW-sivuja
+Comment[fr]=Naviguer sur le Web
+Comment[gl]=Navegar pola rede
+Comment[he]=גלישה ברחבי האינטרנט
+Comment[hr]=Pretražite web
+Comment[hu]=A világháló böngészése
+Comment[it]=Esplora il web
+Comment[ja]=ウェブを閲覧します
+Comment[ko]=웹을 돌아 다닙니다
+Comment[ku]=Li torê bigere
+Comment[lt]=Naršykite internete
+Comment[nb]=Surf på nettet
+Comment[nl]=Verken het internet
+Comment[nn]=Surf på nettet
+Comment[no]=Surf på nettet
+Comment[pl]=Przeglądaj strony WWW z przeglądarką internetową Cyberfox
+Comment[pt]=Explorar a Internet com o Cyberfox
+Comment[pt_BR]=Navegue na Internet
+Comment[ro]=Navigați pe Internet
+Comment[ru]=Доступ в Интернет
+Comment[sk]=Prehliadanie internetu
+Comment[sl]=Brskajte po spletu
+Comment[sv]=Surfa på webben
+Comment[tr]=İnternet'te Gezinin
+Comment[ug]=دۇنيادىكى توربەتلەرنى كۆرگىلى بولىدۇ
+Comment[uk]=Перегляд сторінок Інтернету
+Comment[vi]=Để duyệt các trang web
+Comment[zh_CN]=浏览互联网
+Comment[zh_TW]=瀏覽網際網路
+GenericName=Web Browser
+GenericName[ar]=متصفح ويب
+GenericName[ast]=Restolador Web
+GenericName[bn]=ওয়েব ব্রাউজার
+GenericName[ca]=Navegador web
+GenericName[cs]=Webový prohlížeč
+GenericName[da]=Webbrowser
+GenericName[el]=Περιηγητής διαδικτύου
+GenericName[es]=Navegador web
+GenericName[et]=Veebibrauser
+GenericName[fa]=مرورگر اینترنتی
+GenericName[fi]=WWW-selain
+GenericName[fr]=Navigateur Web
+GenericName[gl]=Navegador Web
+GenericName[he]=דפדפן אינטרנט
+GenericName[hr]=Web preglednik
+GenericName[hu]=Webböngésző
+GenericName[it]=Browser web
+GenericName[ja]=ウェブ・ブラウザ
+GenericName[ko]=웹 브라우저
+GenericName[ku]=Geroka torê
+GenericName[lt]=Interneto naršyklė
+GenericName[nb]=Nettleser
+GenericName[nl]=Webbrowser
+GenericName[nn]=Nettlesar
+GenericName[no]=Nettleser
+GenericName[pl]=Przeglądarka WWW
+GenericName[pt]=Navegador web
+GenericName[pt_BR]=Navegador Web
+GenericName[ro]=Navigator Internet
+GenericName[ru]=Веб-браузер
+GenericName[sk]=Internetový prehliadač
+GenericName[sl]=Spletni brskalnik
+GenericName[sv]=Webbläsare
+GenericName[tr]=Web Tarayıcı
+GenericName[ug]=توركۆرگۈ
+GenericName[uk]=Веб-браузер
+GenericName[vi]=Trình duyệt Web
+GenericName[zh_CN]=网络浏览器
+GenericName[zh_TW]=網路瀏覽器
+Keywords=Internet;WWW;Browser;Web;Explorer
+Keywords[ar]=انترنت;إنترنت;متصفح;ويب;وب
+Keywords[ast]=Internet;WWW;Restolador;Web;Esplorador
+Keywords[ca]=Internet;WWW;Navegador;Web;Explorador;Explorer
+Keywords[cs]=Internet;WWW;Prohlížeč;Web;Explorer
+Keywords[da]=Internet;Internettet;WWW;Browser;Browse;Web;Surf;Nettet
+Keywords[de]=Internet;WWW;Browser;Web;Explorer;Webseite;Site;surfen;online;browsen
+Keywords[el]=Internet;WWW;Browser;Web;Explorer;Διαδίκτυο;Περιηγητής;Cyberfox;Φιρεφοχ;Ιντερνετ
+Keywords[es]=Explorador;Internet;WWW
+Keywords[fi]=Internet;WWW;Browser;Web;Explorer;selain;Internet-selain;internetselain;verkkoselain;netti;surffaa
+Keywords[fr]=Internet;WWW;Browser;Web;Explorer;Fureteur;Surfer;Navigateur
+Keywords[he]=דפדפן;אינטרנט;רשת;אתרים;אתר;פיירפוקס;מוזילה;
+Keywords[hr]=Internet;WWW;preglednik;Web
+Keywords[hu]=Internet;WWW;Böngésző;Web;Háló;Net;Explorer
+Keywords[it]=Internet;WWW;Browser;Web;Navigatore
+Keywords[is]=Internet;WWW;Vafri;Vefur;Netvafri;Flakk
+Keywords[ja]=Internet;WWW;Web;インターネット;ブラウザ;ウェブ;エクスプローラ
+Keywords[nb]=Internett;WWW;Nettleser;Explorer;Web;Browser;Nettside
+Keywords[nl]=Internet;WWW;Browser;Web;Explorer;Verkenner;Website;Surfen;Online 
+Keywords[pl]=Internet;WWW;Przeglądarka;Sieć;Surfowanie;Strona internetowa;Strona;Przeglądanie
+Keywords[pt]=Internet;WWW;Browser;Web;Explorador;Navegador
+Keywords[pt_BR]=Internet;WWW;Browser;Web;Explorador;Navegador
+Keywords[ru]=Internet;WWW;Browser;Web;Explorer;интернет;браузер;веб;файрфокс;огнелис
+Keywords[sk]=Internet;WWW;Prehliadač;Web;Explorer
+Keywords[sl]=Internet;WWW;Browser;Web;Explorer;Brskalnik;Splet
+Keywords[tr]=İnternet;WWW;Tarayıcı;Web;Gezgin;Web sitesi;Site;sörf;çevrimiçi;tara
+Keywords[uk]=Internet;WWW;Browser;Web;Explorer;Інтернет;мережа;переглядач;оглядач;браузер;веб;файрфокс;вогнелис;перегляд
+Keywords[vi]=Internet;WWW;Browser;Web;Explorer;Trình duyệt;Trang web
+Keywords[zh_CN]=Internet;WWW;Browser;Web;Explorer;网页;浏览;上网;火狐;Cyberfox;互联网;网站;
+Keywords[zh_TW]=Internet;WWW;Browser;Web;Explorer;網際網路;網路;瀏覽器;上網;網頁;火狐
+Exec=cyberfox %u
+Terminal=false
+X-MuiltpleArgs=false
+Type=Application
+Icon=cyberfox
+Categories=Network;WebBrowser;
+MimeType=text/html;text/xml;application/xhtml+xml;application/xml;application/rss+xml;application/rdf+xml;image/gif;image/jpeg;image/png;x-scheme-handler/http;x-scheme-handler/https;x-scheme-handler/ftp;x-scheme-handler/chrome;video/webm;application/x-xpinstall;
+StartupWMClass=Cyberfox
+StartupNotify=true
+Actions=NewWindow;NewPrivateWindow;
+
+[Desktop Action NewWindow]
+Name=Open a New Window
+Name[ar]=افتح نافذة جديدة
+Name[ast]=Abrir una ventana nueva
+Name[bn]=Abrir una ventana nueva
+Name[ca]=Obre una finestra nova
+Name[cs]=Otevřít nové okno
+Name[da]=Åbn et nyt vindue
+Name[de]=Ein neues Fenster öffnen
+Name[el]=Άνοιγμα νέου παραθύρου
+Name[es]=Abrir una ventana nueva
+Name[fi]=Avaa uusi ikkuna
+Name[fr]=Ouvrir une nouvelle fenêtre
+Name[gl]=Abrir unha nova xanela
+Name[he]=פתיחת חלון חדש
+Name[hr]=Otvori novi prozor
+Name[hu]=Új ablak nyitása
+Name[it]=Apri una nuova finestra
+Name[ja]=新しいウィンドウを開く
+Name[ko]=새 창 열기
+Name[ku]=Paceyeke nû veke
+Name[lt]=Atverti naują langą
+Name[nb]=Åpne et nytt vindu
+Name[nl]=Nieuw venster openen
+Name[pl]=Otwórz nowe okno
+Name[pt]=Abrir uma nova janela
+Name[pt_BR]=Abrir nova janela
+Name[ro]=Deschide o fereastră nouă
+Name[ru]=Новое окно
+Name[sk]=Otvoriť nové okno
+Name[sl]=Odpri novo okno
+Name[sv]=Öppna ett nytt fönster
+Name[tr]=Yeni pencere aç 
+Name[ug]=يېڭى كۆزنەك ئېچىش
+Name[uk]=Відкрити нове вікно
+Name[vi]=Mở cửa sổ mới
+Name[zh_CN]=新建窗口
+Name[zh_TW]=開啟新視窗
+Exec=cyberfox -new-window
+
+[Desktop Action NewPrivateWindow]
+Name=Open a New Private Window
+Name[ar]=افتح نافذة جديدة للتصفح الخاص
+Name[ca]=Obre una finestra nova en mode d'incògnit
+Name[de]=Ein neues privates Fenster öffnen
+Name[es]=Abrir una ventana privada nueva
+Name[fi]=Avaa uusi yksityinen ikkuna
+Name[fr]=Ouvrir une nouvelle fenêtre de navigation privée
+Name[he]=פתיחת חלון גלישה פרטית חדש
+Name[hu]=Új privát ablak nyitása
+Name[it]=Apri una nuova finestra anonima
+Name[nb]=Åpne et nytt privat vindu
+Name[pl]=Otwórz nowe okno prywatne
+Name[pt]=Abrir uma nova janela privada
+Name[ru]=Новое приватное окно
+Name[sl]=Odpri novo okno zasebnega brskanja
+Name[tr]=Yeni bir pencere aç
+Name[uk]=Відкрити нове вікно у потайливому режимі
+Name[zh_TW]=開啟新隱私瀏覽視窗
+Exec=cyberfox -private-window
+EOF
+            echo "Installing start menu shortcut..."
+            chmod +x $InstallDirectory/Cyberfox/tmp/cyberfox.desktop
+            sudo cp $InstallDirectory/Cyberfox/tmp/cyberfox.desktop $Applications/
 
             # Add KDE Plasma notification integration
             echo "Do you wish to add a KDE Plasma notification integration (Requires root privileges)?"
             select yn in "Yes" "No"; do
                 case $yn in
                     Yes )
-                        echo "To add a KDE Plasma notification integration, root privileges are required!"
                         echo "Adding KDE Plasma notification integration"
                         # Requires admin permissions to write the file to /usr/share/knotifications5 directory.
                         sudo wget -O /usr/share/knotifications5/kyberfoxhelper.notifyrc  https://raw.githubusercontent.com/hawkeye116477/kyberfoxhelper/master/kyberfoxhelper.notifyrc
                     break;;
                     No ) break;;
                 esac
-        
-            # Clone shortcut to /usr/share/applications for access in menus i.e Mint, Ubuntu search etc
-            echo "Do you wish to add a shortcut to your startmenu (Requires root privileges)?"
+            done
+                
+            # Install optional desktop shortcut
+            echo "Do you wish to add a desktop shortcut (Root priveleges are required)?"
             select yn in "Yes" "No"; do
                 case $yn in
                     Yes )
-                        echo "To add a copy of the desktop shortcut to $Applications, root privileges are required!"
-                        echo "Generating menu shortcut"
-                        # Requires admin permissions to write the file to /usr/share/applications directory.
-                        sudo cp $Desktop $Applications
+                        echo "Generating desktop shortcut..."
+                        sudo ln -sf $Applications/cyberfox.desktop $Desktop/cyberfox.desktop
                     break;;
                     No ) break;;
                 esac
             done
-            echo "Cyberfox is now ready for use!"
-            notify-send "Installation Compelete"
+            echo "Cyberfox KDE Plasma Edition is now ready for use!"
+            notify-send "Installation Complete!"
         else
             echo "You must place this script next to the 'Cyberfox_KDE_Plasma_Edition' tar.bz2 package."
-        fi; break;;
+        fi; 
+        rm -rf $InstallDirectory/Cyberfox/tmp
+        break;;
         Uninstall )
 
             # Navigate in to apps directory
@@ -121,15 +323,29 @@ select yn in "Install" "Uninstall" "Quit"; do
             fi
 
             # Remove cyberfox desktop icon if exists.
-            if [ -f $Desktop ]; then
-                rm -vf $Desktop;
+            if [ -f $Desktop/cyberfox.desktop ]; then
+                rm -vrf $Desktop/cyberfox.desktop;
             fi
 			
             # Remove menu icon if exists.
             # Requires admin permissions to write the file to /usr/share/applications directory.
             # This should only prompt if the user installed it, Meaning if the check for the file returns true.
             if [ -f $Applications/cyberfox.desktop ]; then
-                sudo rm -vf $Applications/cyberfox.desktop;
+                sudo rm -vrf $Applications/cyberfox.desktop;
+            fi
+            
+            # Remove symlinks
+            if [ -L /usr/bin/cyberfox ]; then
+                sudo rm -vrf /usr/bin/cyberfox;
+            fi
+            
+            if [ -L /usr/share/pixmaps/cyberfox.png ]; then
+                sudo rm -vrf /usr/share/pixmaps/cyberfox.png;
+            fi
+            
+            # Remove ~/Apps if is empty
+            if [ ! "$(ls -A $InstallDirectory)" ]; then
+                rmdir $InstallDirectory;
             fi
             
             # Remove KDE Plasma notification integration

--- a/_Build/_Linux/install_kyberfox.sh
+++ b/_Build/_Linux/install_kyberfox.sh
@@ -1,0 +1,146 @@
+# Cyberfox KDE Plasma Edition Installation, Shortcut Desktop, (Optional) Shortcut Menu, Cyberfox KDE Plasma Edition Uninstall
+# Version: 1.0
+# Release, Beta channels linux
+
+#!/bin/bash
+
+# Set current directory to script directory.
+Dir=$(cd "$(dirname "$0")" && pwd)
+
+# Enter current script directory.
+cd $Dir
+
+# Count how many packages in the directory, If there is more then one the script may break or have undesired effect.
+PackageCount=`ls Cyberfox_KDE_Plasma_Edition-*.tar.bz2 | awk 'END { print NR }'` 
+
+# Make package name editable in single place in the event of file naming change.
+Package=$Dir/Cyberfox_KDE_Plasma_Edition-*.tar.bz2
+
+# Desktop shortcut path, Applications shortcut path, Cyberfox install path.
+Desktop=~/Desktop/cyberfox.desktop
+Applications=/usr/share/applications
+InstallDirectory=$HOME/Apps
+
+# Check if the script is in the right place before checking file hashes.
+echo "Do you wish to install Cyberfox now?"
+select yn in "Install" "Uninstall" "Quit"; do
+    case $yn in
+        Install )
+
+        # Check if more than 1 package exist.
+        if [ $PackageCount -gt 1 ]; then  
+            echo "You have to many packages [$PackageCount] in this directory, I am unable to compute what package to install, Please remove the other packages so i no longer get confused!"
+            notify-send "A error has occured"
+            exit 0 
+        fi;
+
+
+        if [ -f $Dir/Cyberfox_KDE_Plasma_Edition-*.tar.bz2 ]; then
+		
+            # Make directory if not already exist
+            if ! [ -d $InstallDirectory ]; then
+                echo "Making $InstallDirectory directory!"
+                mkdir $InstallDirectory
+            fi
+			
+            # Navigate in to apps directory
+            echo "Entering $InstallDirectory directory"
+            cd $InstallDirectory
+			
+            # Unpack cyberfox in to apps directory, Remove existing cyberfox folder.
+            if [ -d $InstallDirectory/Cyberfox ]; then
+                echo "Removing older install $InstallDirectory/Cyberfox"
+                rm -rvf $InstallDirectory/Cyberfox;
+            fi
+			
+            echo "Unpacking $Package in to $InstallDirectory directory"
+            tar xjfv $Package
+
+            # Remove readme.txt it has no place in apps directory.
+            if [ -f $InstallDirectory/README.txt ]; then
+                rm -rvf $InstallDirectory/README.txt;
+            fi
+
+            # Create desktop shortcut
+            echo "Generating desktop shortcut"
+            echo "[Desktop Entry]" > $Desktop
+            echo "Encoding=UTF-8" >> $Desktop
+            echo "Name=Cyberfox" >> $Desktop
+            echo "Comment=Starts Cyberfox Web Browser" >> $Desktop
+            echo "Exec=$InstallDirectory/Cyberfox/Cyberfox" >> $Desktop
+            echo "Icon=$InstallDirectory/Cyberfox/browser/icons/mozicon128.png" >> $Desktop
+            echo "Terminal=false" >> $Desktop
+            echo "X-MuiltpleArgs=false" >> $Desktop
+            echo "StartupWMClass=Cyberfox" >> $Desktop
+            echo "Type=Application" >> $Desktop
+            echo "Categories=Network;WebBrowser;" >> $Desktop
+            echo "MimeType=text/html;text/xml;application/xhtml+xml;application/xml;application/rss+xml;application/rdf+xml;image/gif;image/jpeg;image/png;x-scheme-handler/http;x-scheme-handler/https;x-scheme-handler/ftp;x-scheme-handler/chrome;video/webm;application/x-xpinstall;" >> $Desktop
+            chmod +x $Desktop
+
+            # Add KDE Plasma notification integration
+            echo "Do you wish to add a KDE Plasma notification integration (Requires root privileges)?"
+            select yn in "Yes" "No"; do
+                case $yn in
+                    Yes )
+                        echo "To add a KDE Plasma notification integration, root privileges are required!"
+                        echo "Adding KDE Plasma notification integration"
+                        # Requires admin permissions to write the file to /usr/share/knotifications5 directory.
+                        sudo wget -O /usr/share/knotifications5/kyberfoxhelper.notifyrc  https://raw.githubusercontent.com/hawkeye116477/kyberfoxhelper/master/kyberfoxhelper.notifyrc
+                    break;;
+                    No ) break;;
+                esac
+        
+            # Clone shortcut to /usr/share/applications for access in menus i.e Mint, Ubuntu search etc
+            echo "Do you wish to add a shortcut to your startmenu (Requires root privileges)?"
+            select yn in "Yes" "No"; do
+                case $yn in
+                    Yes )
+                        echo "To add a copy of the desktop shortcut to $Applications, root privileges are required!"
+                        echo "Generating menu shortcut"
+                        # Requires admin permissions to write the file to /usr/share/applications directory.
+                        sudo cp $Desktop $Applications
+                    break;;
+                    No ) break;;
+                esac
+            done
+            echo "Cyberfox is now ready for use!"
+            notify-send "Installation Compelete"
+        else
+            echo "You must place this script next to the 'Cyberfox_KDE_Plasma_Edition' tar.bz2 package."
+        fi; break;;
+        Uninstall )
+
+            # Navigate in to apps directory
+            echo "Entering $InstallDirectory directory"
+            cd $InstallDirectory
+
+            # Remove cyberfox installation folder
+            if [ -d $InstallDirectory/Cyberfox ]; then
+                echo "Removing older install $InstallDirectory/Cyberfox"
+                rm -rvf $InstallDirectory/Cyberfox;
+            fi
+
+            # Remove cyberfox desktop icon if exists.
+            if [ -f $Desktop ]; then
+                rm -vf $Desktop;
+            fi
+			
+            # Remove menu icon if exists.
+            # Requires admin permissions to write the file to /usr/share/applications directory.
+            # This should only prompt if the user installed it, Meaning if the check for the file returns true.
+            if [ -f $Applications/cyberfox.desktop ]; then
+                sudo rm -vf $Applications/cyberfox.desktop;
+            fi
+            
+            # Remove KDE Plasma notification integration
+             if [ -f /usr/share/knotifications5/kyberfoxhelper.notifyrc ]; then
+                sudo rm -vf /usr/share/knotifications5/kyberfoxhelper.notifyrc;
+            fi
+            
+			notify-send "Uninstall Complete"
+        break;;
+	  "Quit" )
+            echo "If I’m not back in five minutes, just wait longer."
+			exit 0; break;;
+    esac
+done

--- a/browser/app/profile/firefox.js
+++ b/browser/app/profile/firefox.js
@@ -193,7 +193,9 @@ pref("browser.customizemode.tip0.learnMoreUrl", "https://support.mozilla.org/1/f
 pref("keyword.enabled", true);
 pref("browser.fixup.domainwhitelist.localhost", true);
 
+#ifdef XP_WIN || XP_MACOSX
 pref("general.useragent.locale", "@AB_CD@");
+#endif
 pref("general.skins.selectedSkin", "classic/1.0");
 
 pref("general.smoothScroll", true);

--- a/browser/branding/branding-common.mozbuild
+++ b/browser/branding/branding-common.mozbuild
@@ -46,6 +46,9 @@ def FirefoxBranding():
     elif 'gtk' in CONFIG['MOZ_WIDGET_TOOLKIT']:
         BRANDING_FILES += [
             'default16.png',
+            'default22.png',
+            'default24.png',
+            'default256.png',
             'default32.png',
             'default48.png',
             'mozicon128.png',
@@ -53,6 +56,9 @@ def FirefoxBranding():
         FINAL_TARGET_FILES.icons += ['mozicon128.png']
         FINAL_TARGET_FILES.chrome.icons.default += [
             'default16.png',
+            'default22.png',
+            'default24.png',
+            'default256.png',
             'default32.png',
             'default48.png',
         ]

--- a/browser/components/preferences/content.js
+++ b/browser/components/preferences/content.js
@@ -398,6 +398,7 @@ var gContentPane = {
   updateDefaultLocale: function ()
   {
 	  document.getElementById("languageMenu").value = Services.prefs.getCharPref('general.useragent.locale');
+      Services.prefs.setBoolPref('intl.locale.matchOS', false);
   },
   setDefaultLocale: function ()
   {	  

--- a/browser/components/preferences/in-content/content.js
+++ b/browser/components/preferences/in-content/content.js
@@ -355,6 +355,7 @@ var gContentPane = {
   updateDefaultLocale: function ()
   {
 	  document.getElementById("languageMenu").value = Services.prefs.getCharPref('general.useragent.locale');
+      Services.prefs.setBoolPref('intl.locale.matchOS', false);
   },
   setDefaultLocale: function ()
   {	  

--- a/browser/installer/package-manifest.in
+++ b/browser/installer/package-manifest.in
@@ -607,8 +607,11 @@
 @RESPATH@/chrome/recording/*
 #ifdef MOZ_GTK
 @RESPATH@/browser/chrome/icons/default/default16.png
+@RESPATH@/browser/chrome/icons/default/default22.png
+@RESPATH@/browser/chrome/icons/default/default24.png
 @RESPATH@/browser/chrome/icons/default/default32.png
 @RESPATH@/browser/chrome/icons/default/default48.png
+@RESPATH@/browser/chrome/icons/default/default256.png
 #endif
 @RESPATH@/browser/features/*
 

--- a/browser/locales/en-US/firefox-l10n.js
+++ b/browser/locales/en-US/firefox-l10n.js
@@ -2,10 +2,14 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+
 #filter substitution
+
 
 # LOCALIZATION NOTE: this preference is set to true for en-US specifically,
 # locales without this line have the setting set to false by default.
 pref("browser.search.geoSpecificDefaults", false);
 
+#ifdef XP_WIN || XP_MACOSX
 pref("general.useragent.locale", "@AB_CD@");
+#endif

--- a/toolkit/system/unixproxy/nsUnixSystemProxySettings.cpp
+++ b/toolkit/system/unixproxy/nsUnixSystemProxySettings.cpp
@@ -59,13 +59,17 @@ nsUnixSystemProxySettings::GetMainThreadOnly(bool *aMainThreadOnly)
 nsresult
 nsUnixSystemProxySettings::Init()
 {
-  mGSettings = do_GetService(NS_GSETTINGSSERVICE_CONTRACTID);
-  if (mGSettings) {
-    mGSettings->GetCollectionForSchema(NS_LITERAL_CSTRING("org.gnome.system.proxy"),
-                                       getter_AddRefs(mProxySettings));
-  }
-  if (!mProxySettings) {
-    mGConf = do_GetService(NS_GCONFSERVICE_CONTRACTID);
+  // only use GSettings if that is a GNOME session
+  const char* sessionType = PR_GetEnv("DESKTOP_SESSION");
+  if (sessionType && !strcmp(sessionType, "gnome")) {
+    mGSettings = do_GetService(NS_GSETTINGSSERVICE_CONTRACTID);
+    if (mGSettings) {
+      mGSettings->GetCollectionForSchema(NS_LITERAL_CSTRING("org.gnome.system.proxy"),
+                                         getter_AddRefs(mProxySettings));
+    }
+    if (!mProxySettings) {
+      mGConf = do_GetService(NS_GCONFSERVICE_CONTRACTID);
+    }
   }
   
   return NS_OK;


### PR DESCRIPTION
Welcome Toady! I added some useful patches for Cyberfox Linux and created script for building and installing Cyberfox KDE Plasma Edition aka 'Kyberfox'.
To make properly working 'Kyberfox', we need modified OpenSuse's kmozillahelper, so I added to script adding precompiled binary of kyberfoxhelper (to compile kyberfoxhelper you need KF5 libs, I assume that you don't have KDE or KF5 libs, so I compiled it by myself and added to build script adding precompiled binary of kyberfoxhelper). Optionally for KDE notification integration is kyberfoxhelper.notifyrc file, It must be placed into /usr/share/knotifications5/ , so I added this only for install script.
While building 'Kyberfox' may be the messages like "Patch hunk failed jar.mn", but all should be fine, because I added next patch as fix for this.

I also improved install scripts for Cyberfox.

